### PR TITLE
Fix "Consider an iterator instead of materializing the list" issue

### DIFF
--- a/test/test_Spectrum.py
+++ b/test/test_Spectrum.py
@@ -45,8 +45,8 @@ def test_wav_select(x, calib, wav_min, wav_max):
     # All values in selected spectrum should be less than the max and greater
     # than the min value.
     if isinstance(spec.xaxis, list):
-        assert all([xval >= wav_min for xval in spec.xaxis])
-        assert all([xval <= wav_max for xval in spec.xaxis])
+        assert all( xval >= wav_min for xval in spec.xaxis)
+        assert all( xval <= wav_max for xval in spec.xaxis)
     else:
         assert all(spec.xaxis >= wav_min)
         assert all(spec.xaxis <= wav_max)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Consider an iterator instead of materializing the list](https://www.quantifiedcode.com/app/issue_class/53lnAzfW)
Issue details: [https://www.quantifiedcode.com/app/project/gh:jason-neal:spectrum_overload?groups=code_patterns/%3A53lnAzfW](https://www.quantifiedcode.com/app/project/gh:jason-neal:spectrum_overload?groups=code_patterns/%3A53lnAzfW)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)