### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/spectrum_overload/__about__.py
+++ b/spectrum_overload/__about__.py
@@ -37,4 +37,4 @@ __author__ = "Jason Neal"
 __email__ = "jason.neal@astro.up.pt"
 
 __license__ = "MIT Licence"
-__copyright__ = "2016 %s" % __author__
+__copyright__ = "2016 {0!s}".format(__author__)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:jason-neal:spectrum_overload?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:jason-neal:spectrum_overload?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)